### PR TITLE
Add support for data and blob URL schemes

### DIFF
--- a/notifications.js
+++ b/notifications.js
@@ -13,7 +13,7 @@ var notifications = null;
 var notificationOptions = null;
 
 function resolveUri(uri) {
-    if (uri.indexOf('chrome-extension') === 0) {
+    if (uri.indexOf('chrome-extension') === 0 || uri.indexOf('data:image') === 0  || uri.indexOf('blob') === 0) {
         return uri;
     } else {
         return runtime.getURL(uri);


### PR DESCRIPTION
The `iconUrl` property should accept `data:image` and `blob` url schemes too.

According to the specification:

> #### NotificationOptions
> 
> **`iconUrl`** (optional)	
> A URL to the sender's avatar, app icon, or a thumbnail for image notifications.
>
>
> URLs can be a data URL, a blob URL, or a URL relative to a resource within this extension's .crx file *Required for* **notifications.create** method.

![screenshot](https://cloud.githubusercontent.com/assets/812964/7898245/3172e4bc-06fa-11e5-99c9-e77f9e443be4.png)


See https://developer.chrome.com/apps/notifications#property-NotificationOptions-iconUrl