### PR TITLE
Added set defaults on notification builder

### DIFF
--- a/src/android/ChromeNotifications.java
+++ b/src/android/ChromeNotifications.java
@@ -153,6 +153,7 @@ public class ChromeNotifications extends CordovaPlugin {
             .setContentTitle(options.getString("title"))
             .setContentText(options.getString("message"))
             .setLargeIcon(largeIcon)
+            .setDefaults(Notification.DEFAULT_ALL)
             .setPriority(options.optInt("priority"))
             .setContentIntent(makePendingIntent(NOTIFICATION_CLICKED_ACTION, notificationId, -1, PendingIntent.FLAG_CANCEL_CURRENT))
             .setDeleteIntent(makePendingIntent(NOTIFICATION_CLOSED_ACTION, notificationId, -1, PendingIntent.FLAG_CANCEL_CURRENT));


### PR DESCRIPTION
The NotificationCompat builder isn't setting defaults when it creates the notification.  I had to make this change in the version of this plugin I use for my project because otherwise notifications set with high priority wouldn't make the mobile device vibrate or show the notification LED.  In Lollipop and Marshmallow the notifications designated as high priority wouldn't do that new thing where they briefly overlay the currently active notification.

I'm not sure if using DEFAULT_ALL is appropriate for general purpose use cases or not, hopefully someone with more knowledge of Android development can determine if there are negative side effects to utilizing this setting.  All I know for certain is that adding this line of code to the plugin made the chrome app notifications surface as I expected them to in Android based on priority settings, whereas without this line all high priority notifications were very difficult to notice because there was no notification LED or vibration and no in your face pop-up on Lollipop.